### PR TITLE
Stop using JSON-P for info.json.

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -48,7 +48,7 @@ $(document).ready(function(){
 		// $("#imgZoomLabel").text(label);
 	        var promises = []
 		promises.push(setOverlaySize());
-		promises.push( $.getJSON(url + CB,
+		promises.push( $.getJSON(url,
 			      function(data) {
 				      if(typeof o !== 'undefined'){
 					o.destroy();
@@ -67,7 +67,6 @@ $(document).ready(function(){
 	});
 	
 	/* LORIS stuff */
-	var CB = '?callback=?'
 	var rotation = 0;
 	
 	var osd_config = {


### PR DESCRIPTION
Refs https://github.com/pulibrary/figgy/issues/5022

To test this you have to `gem install jekyll` and then `jekyll serve --watch` and go to `localhost:4000` then click any of the zoomable images and make sure zooming works.